### PR TITLE
EZP-24924: Moved form mapper from repo forms

### DIFF
--- a/bundle/DependencyInjection/EzSystemsEzPlatformPageFieldTypeExtension.php
+++ b/bundle/DependencyInjection/EzSystemsEzPlatformPageFieldTypeExtension.php
@@ -42,6 +42,7 @@ class EzSystemsEzPlatformPageFieldTypeExtension extends Extension implements Pre
         $loader->load('indexable_fieldtypes.yml');
         $loader->load('storage_engines/legacy/external_storage_gateways.yml');
         $loader->load('storage_engines/legacy/field_value_converters.yml');
+        $loader->load('forms.yml');
 
         // Load bundle configuration
         $loader = new Loader\YamlFileLoader(

--- a/lib/FieldType/Page/PageFormMapper.php
+++ b/lib/FieldType/Page/PageFormMapper.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the eZ RepositoryForms package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\FieldType\Page;
+
+use eZ\Publish\Core\FieldType\Page\PageService;
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldTypeFormMapperInterface;
+use Symfony\Component\Form\FormInterface;
+
+class PageFormMapper implements FieldTypeFormMapperInterface
+{
+    /**
+     * @var PageService Provides layout list used in form selector
+     */
+    protected $pageService;
+
+    /**
+     * @param PageService $pageService
+     */
+    public function __construct(PageService $pageService)
+    {
+        $this->pageService = $pageService;
+    }
+
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
+    {
+        $availableLayouts = $this->pageService->getAvailableZoneLayouts();
+
+        $fieldDefinitionForm
+            ->add('defaultLayout', 'choice', [
+                'choices' => array_combine($availableLayouts, $availableLayouts),
+                'multiple' => false,
+                'expanded' => false,
+                'required' => false,
+                'property_path' => 'fieldSettings[defaultLayout]',
+                'label' => 'field_definition.ezpage.default_layout',
+            ]);
+    }
+}

--- a/lib/settings/forms.yml
+++ b/lib/settings/forms.yml
@@ -1,0 +1,9 @@
+parameters:
+    ezrepoforms.field_type.form_mapper.ezpage.class: eZ\Publish\Core\FieldType\Page\PageFormMapper
+
+class:
+    ezrepoforms.field_type.form_mapper.ezpage:
+        class: %ezrepoforms.field_type.form_mapper.ezpage.class%
+        arguments: [@ezpublish.fieldType.ezpage.pageService]
+        tags:
+            - { name: ez.fieldType.formMapper, fieldType: ezpage }


### PR DESCRIPTION
Part of the extraction story.

Moves the FormMapper from the repository-forms package to this one. Class location can be discussed.
